### PR TITLE
Make English the default locale

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -47,7 +47,7 @@ module.exports = function (eleventyConfig) {
     });
 
     // Date formatting filter
-    eleventyConfig.addFilter("dateFormat", function (date, locale = "ar") {
+    eleventyConfig.addFilter("dateFormat", function (date, locale = "en") {
         return new Date(date).toLocaleDateString(locale === "en" ? "en-US" : "ar-EG", {
             year: "numeric",
             month: "long",
@@ -78,7 +78,7 @@ module.exports = function (eleventyConfig) {
         return arr.slice(0, limit);
     });
 
-    eleventyConfig.addNunjucksGlobal("t", function (key, locale = "ar", options = {}) {
+    eleventyConfig.addNunjucksGlobal("t", function (key, locale = "en", options = {}) {
         if (!i18n.exists(key, { lng: locale })) {
             throw new Error(`Missing translation key "${key}" for locale "${locale}".`);
         }
@@ -86,11 +86,11 @@ module.exports = function (eleventyConfig) {
         return i18n.t(key, { lng: locale, ...options });
     });
 
-    eleventyConfig.addNunjucksGlobal("localeUrl", function (url, locale = "ar") {
+    eleventyConfig.addNunjucksGlobal("localeUrl", function (url, locale = "en") {
         return localizeUrl(url, locale);
     });
 
-    eleventyConfig.addNunjucksGlobal("alternateLocaleUrl", function (url, locale = "ar") {
+    eleventyConfig.addNunjucksGlobal("alternateLocaleUrl", function (url, locale = "en") {
         return localizeUrl(url, locale === "en" ? "ar" : "en");
     });
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,11 +28,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build CSS
-        run: npm run build:css
-
       - name: Build site
-        run: npm run build:11ty
+        run: npm run build
         env:
           DISCORD_GUILD_ID: ${{ secrets.DISCORD_GUILD_ID }}
           DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}

--- a/content/blogs/blogs.11tydata.js
+++ b/content/blogs/blogs.11tydata.js
@@ -11,7 +11,7 @@ module.exports = {
         dir: (data) => data.localeData.dir,
         permalink: (data) => {
             const slug = data.page.fileSlug;
-            return data.localeData.code === "en" ? `/en/blogs/${slug}/` : `/blogs/${slug}/`;
+            return `${data.localeData.prefix}/blogs/${slug}/`.replace(/^\/\//, "/");
         }
     }
 };

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build:11ty": "eleventy",
     "watch:11ty": "eleventy --serve",
     "verify:i18n-build": "node scripts/verify-localized-build.js",
-    "build": "npm run check:i18n && npm run build:css && npm run build:11ty && npm run verify:i18n-build",
+    "build": "npm run clean && npm run check:i18n && npm run build:css && npm run build:11ty && npm run verify:i18n-build",
     "dev": "npm-run-all --parallel watch:*",
     "clean": "rm -rf _site"
   },

--- a/scripts/verify-localized-build.js
+++ b/scripts/verify-localized-build.js
@@ -11,12 +11,23 @@ function ensureExists(relativePath) {
     }
 }
 
+function ensureContains(relativePath, expectedText) {
+    const absolutePath = path.join(root, relativePath);
+    const content = fs.readFileSync(absolutePath, "utf8");
+    if (!content.includes(expectedText)) {
+        throw new Error(`Built file ${relativePath} does not include expected text: ${expectedText}`);
+    }
+}
+
 const pages = [
     "index.html",
-    path.join("en", "index.html"),
+    path.join("ar", "index.html"),
     path.join("blogs", "index.html"),
-    path.join("en", "blogs", "index.html"),
+    path.join("ar", "blogs", "index.html"),
     path.join("contributing", "index.html"),
+    path.join("ar", "contributing", "index.html"),
+    path.join("en", "index.html"),
+    path.join("en", "blogs", "index.html"),
     path.join("en", "contributing", "index.html")
 ];
 
@@ -24,13 +35,19 @@ for (const page of pages) {
     ensureExists(page);
 }
 
+ensureContains(path.join("en", "index.html"), "url=/");
+ensureContains(path.join("en", "blogs", "index.html"), "url=/blogs/");
+ensureContains(path.join("en", "contributing", "index.html"), "url=/contributing/");
+
 const postFiles = fs.readdirSync(blogDir)
     .filter((file) => file.endsWith(".md") && file !== "0template.md")
     .map((file) => path.basename(file, ".md"));
 
 for (const slug of postFiles) {
     ensureExists(path.join("blogs", slug, "index.html"));
+    ensureExists(path.join("ar", "blogs", slug, "index.html"));
     ensureExists(path.join("en", "blogs", slug, "index.html"));
+    ensureContains(path.join("en", "blogs", slug, "index.html"), `url=/blogs/${slug}/`);
 }
 
 console.log("Localized build output verified.");

--- a/src/_data/enRedirects.js
+++ b/src/_data/enRedirects.js
@@ -1,0 +1,21 @@
+const fs = require("fs");
+const path = require("path");
+
+const blogDir = path.join(__dirname, "..", "..", "content", "blogs");
+
+function getBlogSlugs() {
+    return fs.readdirSync(blogDir)
+        .filter((file) => file.endsWith(".md") && file !== "0template.md")
+        .map((file) => path.basename(file, ".md"))
+        .sort();
+}
+
+module.exports = [
+    { from: "/en/", to: "/" },
+    { from: "/en/blogs/", to: "/blogs/" },
+    { from: "/en/contributing/", to: "/contributing/" },
+    ...getBlogSlugs().map((slug) => ({
+        from: `/en/blogs/${slug}/`,
+        to: `/blogs/${slug}/`
+    }))
+];

--- a/src/_data/locales.js
+++ b/src/_data/locales.js
@@ -1,16 +1,16 @@
 module.exports = [
     {
-        code: "ar",
-        lang: "ar",
-        dir: "rtl",
-        label: "العربية",
-        prefix: ""
-    },
-    {
         code: "en",
         lang: "en",
         dir: "ltr",
         label: "English",
-        prefix: "/en"
+        prefix: ""
+    },
+    {
+        code: "ar",
+        lang: "ar",
+        dir: "rtl",
+        label: "العربية",
+        prefix: "/ar"
     }
 ];

--- a/src/assets/js/main.js
+++ b/src/assets/js/main.js
@@ -1,7 +1,7 @@
 document.addEventListener("DOMContentLoaded", () => {
-    const currentLocale = window.location.pathname.startsWith("/en/") || window.location.pathname === "/en/"
-        ? "en"
-        : "ar";
+    const currentLocale = window.location.pathname.startsWith("/ar/") || window.location.pathname === "/ar/"
+        ? "ar"
+        : "en";
 
     try {
         window.localStorage.setItem("bleu-locale", currentLocale);
@@ -30,7 +30,7 @@ document.addEventListener("DOMContentLoaded", () => {
     document.querySelectorAll(".lang-switcher").forEach((switcher) => {
         switcher.addEventListener("change", (event) => {
             const targetUrl = event.target.value;
-            const targetLocale = targetUrl.startsWith("/en/") || targetUrl === "/en/" ? "en" : "ar";
+            const targetLocale = targetUrl.startsWith("/ar/") || targetUrl === "/ar/" ? "ar" : "en";
 
             try {
                 window.localStorage.setItem("bleu-locale", targetLocale);

--- a/src/blogs.11tydata.js
+++ b/src/blogs.11tydata.js
@@ -8,7 +8,7 @@ module.exports = {
         locale: (data) => data.localeData.code,
         lang: (data) => data.localeData.lang,
         dir: (data) => data.localeData.dir,
-        permalink: (data) => data.localeData.code === "en" ? "/en/blogs/" : "/blogs/",
+        permalink: (data) => `${data.localeData.prefix}/blogs/`.replace(/^\/\//, "/"),
         pageTitleKey: () => "blogs:meta.title",
         pageDescriptionKey: () => "blogs:meta.description"
     }

--- a/src/contributing.11tydata.js
+++ b/src/contributing.11tydata.js
@@ -8,7 +8,7 @@ module.exports = {
         locale: (data) => data.localeData.code,
         lang: (data) => data.localeData.lang,
         dir: (data) => data.localeData.dir,
-        permalink: (data) => data.localeData.code === "en" ? "/en/contributing/" : "/contributing/",
+        permalink: (data) => `${data.localeData.prefix}/contributing/`.replace(/^\/\//, "/"),
         pageTitleKey: () => "contributing:meta.title",
         pageDescriptionKey: () => "contributing:meta.description"
     }

--- a/src/en-redirects.njk
+++ b/src/en-redirects.njk
@@ -1,0 +1,25 @@
+---
+pagination:
+  data: enRedirects
+  size: 1
+  alias: redirect
+permalink: "{{ redirect.from }}"
+eleventyExcludeFromCollections: true
+---
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Redirecting | BLEU Community</title>
+  <meta name="robots" content="noindex">
+  <meta http-equiv="refresh" content="0; url={{ redirect.to }}">
+  <link rel="canonical" href="{{ site.url }}{{ redirect.to }}">
+</head>
+<body>
+  <p>Redirecting to <a href="{{ redirect.to }}">{{ redirect.to }}</a>.</p>
+  <script>
+    window.location.replace("{{ redirect.to }}");
+  </script>
+</body>
+</html>

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -47,7 +47,7 @@ function createI18nInstance() {
 
     instance.init({
         resources,
-        lng: "ar",
+        lng: "en",
         fallbackLng: false,
         initImmediate: false,
         interpolation: {
@@ -147,24 +147,20 @@ function getLocaleConfig(locale) {
 
 function localizeUrl(url, locale) {
     if (!url || typeof url !== "string") {
-        return locale === "en" ? "/en/" : "/";
+        return locale === "ar" ? "/ar/" : "/";
     }
 
     const normalized = url === "/" ? "/" : url.replace(/\/+$/, "") + "/";
 
-    if (locale === "en") {
-        if (normalized === "/") {
-            return "/en/";
-        }
-
-        return normalized.startsWith("/en/") ? normalized : `/en${normalized}`;
+    if (locale === "ar") {
+        return normalized.startsWith("/ar/") ? normalized : `/ar${normalized}`;
     }
 
-    if (normalized === "/en/") {
+    if (normalized === "/ar/") {
         return "/";
     }
 
-    return normalized.startsWith("/en/") ? normalized.replace(/^\/en/, "") || "/" : normalized;
+    return normalized.startsWith("/ar/") ? normalized.replace(/^\/ar/, "") || "/" : normalized;
 }
 
 module.exports = {

--- a/src/index.11tydata.js
+++ b/src/index.11tydata.js
@@ -8,7 +8,7 @@ module.exports = {
         locale: (data) => data.localeData.code,
         lang: (data) => data.localeData.lang,
         dir: (data) => data.localeData.dir,
-        permalink: (data) => data.localeData.code === "en" ? "/en/" : "/",
+        permalink: (data) => data.localeData.prefix ? `${data.localeData.prefix}/` : "/",
         pageTitleKey: () => "home:meta.title",
         pageDescriptionKey: () => "home:meta.description"
     }


### PR DESCRIPTION
## what does this do
  - make English the default language at `/`
  - move Arabic pages under `/ar`
  - backward compatibility: existing `/en` links redirects to `/`
  - generate redirects automatically for all blog posts
  - clean the build output before rebuilding
  - verify English, Arabic, and compatibility redirect output in CI

  ## Routes

  - `/` → English
  - `/ar/` → Arabic
  - `/en/` → redirects to `/`
  - `/en/blogs/...` → redirects to `/blogs/...`